### PR TITLE
Lazy reading from file & test fixes.

### DIFF
--- a/src/clojure_csv/core.clj
+++ b/src/clojure_csv/core.clj
@@ -29,6 +29,36 @@ and quotes. The main functions are parse-csv and write-csv."}
     *strict* false)
 
 ;;
+;; Adapt to char-seq
+;;
+(defmulti char-seq
+  "Adapt object to character seq, based on class. Pass-through for ISeq."
+  class)
+
+(defmethod char-seq java.lang.String [a-str] (seq a-str))
+
+(defmethod char-seq (Class/forName "[I") [arr] (map char arr))
+
+(defmethod char-seq (Class/forName "[B") [arr] (map char arr))
+
+(defmethod char-seq (Class/forName "[C") [arr] arr)
+
+(defmethod char-seq java.io.Reader [a-reader]
+  (letfn [(read-one []
+            (try
+              (let [^int c (.read a-reader)]
+                (when (not= -1 c)
+                  (cons (char c) (lazy-cat (read-one)))))
+              (catch java.io.EOFException eof nil)))]
+    (lazy-seq (read-one))))
+
+(defmethod char-seq clojure.lang.ISeq [se] se)
+
+(defmethod char-seq :default [_]
+  (throw (java.io.IOException. "Don't know how to proceed.")))
+
+
+;;
 ;; CSV Input
 ;;
 

--- a/test/test_csv.clj
+++ b/test/test_csv.clj
@@ -1,11 +1,32 @@
 (ns test-csv
+  (:import [java.io StringReader])
   (:use clojure.test
         clojure-csv.core))
+
+(defn- i-arr [^String s] (int-array (map int s)))
+
+(defn- b-arr [^String s] (byte-array (map (comp byte int) s)))
+
+(defn- c-arr [^String s] (char-array s))
 
 (deftest basic-functionality
   (is (= [["a" "b" "c"]] (parse-csv "a,b,c")))
   (is (= [["" ""]] (parse-csv ",")))
   (is (= [[""]] (parse-csv ""))))
+
+(deftest alternate-sources
+  (is (= [["a" "b" "c"]] (parse-csv (char-seq (i-arr "a,b,c")))))
+  (is (= [["" ""]] (parse-csv (char-seq (i-arr ",")))))
+  (is (= [[""]] (parse-csv (char-seq (i-arr "")))))
+  (is (= [["a" "b" "c"]] (parse-csv (char-seq (b-arr "a,b,c")))))
+  (is (= [["" ""]] (parse-csv (char-seq (b-arr ",")))))
+  (is (= [[""]] (parse-csv (char-seq (b-arr "")))))
+  (is (= [["a" "b" "c"]] (parse-csv (char-seq (c-arr "a,b,c")))))
+  (is (= [["" ""]] (parse-csv (char-seq (c-arr ",")))))
+  (is (= [[""]] (parse-csv (char-seq (c-arr "")))))
+  (is (= [["a" "b" "c"]] (parse-csv (char-seq (StringReader. "a,b,c")))))
+  (is (= [["" ""]] (parse-csv (char-seq (StringReader. ",")))))
+  (is (= [[""]] (parse-csv (char-seq (StringReader. ""))))))
 
 (deftest quoting
   (is (= [["Before", "\"","After"]] (parse-csv "Before,\"\"\"\",After")))
@@ -53,8 +74,10 @@
 (deftest strictness
   ;; I can't figure out why, but the thrown? tests always fail, even though
   ;; entering the test clause by hand gives correct results.
-  ;(is (thrown? Exception (binding [*strict* true] (parse-csv "a,b,c,\"d"))))
-  ;(is (thrown? Exception (binding [*strict* true] (parse-csv "a,b,c,d\"e"))))
+  ;; A: it's because you do not force evaluation without dorun, while
+  ;; at REPL you evaluate when you print out the result. :) -- SMG
+  (is (thrown? Exception (binding [*strict* true] (dorun (parse-csv "a,b,c,\"d")))))
+  (is (thrown? Exception (binding [*strict* true] (dorun (parse-csv "a,b,c,d\"e")))))
   (is (= [["a","b","c","d"]]
          (binding [*strict* false] (parse-csv "a,b,c,\"d"))))
   (is (= [["a","b","c","d"]]
@@ -64,3 +87,11 @@
   (is (= [["120030" "BLACK COD FILET MET VEL \"MSC\"" "KG" "0" "1"]]
        (binding [*strict* false *delimiter* \;]
          (parse-csv "120030;BLACK COD FILET MET VEL \"MSC\";KG;0;1")))))
+
+(deftest reader-cases
+  ;; reader will be created and closed in with-open, but used outside.
+  ;; this is actually a java.io.IOException, but thrown at runtime so...
+  (is (thrown? java.lang.RuntimeException
+               (dorun (with-open [sr (StringReader. "a,b,c")]
+                        (parse-csv (char-seq sr)))))))
+


### PR DESCRIPTION
Hi David,

I have added some code that let's me evaluate CSV without reading the entire file into memory at once (multi-method for java.io.Reader). Wrote some tests for that.

Also fixed your two tests regarding exception throwing during parsing with *strict*.

I'm not saying that you should merge this commit as is, but having a way to work with files lazily (read and maybe even write) would be awesome and this is one way to do it (without changing any of your parsing logic and mechanisms, with a small addin). Also -- please take a look at fixed tests.

Regards,
Slawek.
