### PR TITLE
Tell which namespace to use in the Use section of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cake deps
 
 Use
 ---
-There are two functions exposed to the user: 
+The **clojure-csv.core** namespace exposes two functions to the user: 
 
 ### parse-csv
 Takes a CSV as a char sequence or string, and returns a lazy sequence of 


### PR DESCRIPTION
Currently, the namespace the user is supposed to use is only mentioned in the Previously section of the README. Which namespace should be used should be clearly visible in the README so that the user does not have to resort to crack open the jar file out of frustration. :-)
