### PR TITLE
Additionally handle single CR newlines.

### DIFF
--- a/src/clojure_csv/core.clj
+++ b/src/clojure_csv/core.clj
@@ -189,7 +189,7 @@ and quotes. The main functions are parse-csv and write-csv."}
   (or (.contains cell (str *delimiter*))
       (.contains cell "\"")
       (.contains cell "\n")
-      (.contains cell "\r\n")))
+      (.contains cell "\r")))
 
 (defn- escape
   "Given a character, returns the escaped version, whether that is the same


### PR DESCRIPTION
Dropping the check to for either CR or LF captures a few more 'in the wild' combinations of newlines (CR,LF,CR+LF, and LF+CR).
