### PR TITLE
Add license information to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,7 @@
 (defproject clojure-csv "2.0.2"
   :description "A simple library to read and write CSV files."
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.3.0"]]
   :plugins [[perforate "0.3.2"]]
   :jvm-opts ["-Xmx1g"]


### PR DESCRIPTION
Hi David,

I use VersionEye on some of my projects and it tries to check license info for any dependencies 
Since the project.clj is missing license info it is giving a warning for clojure-csv.
If you don't have any arguments against adding this I'd appreciate it!

Thanks for al the great work on this project!
