### PR TITLE
Update library version to 2.0.2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Obtaining
 ---------
 If you are using Leiningen, you can simply add
 
-    [clojure-csv/clojure-csv "2.0.1"]
+    [clojure-csv/clojure-csv "2.0.2"]
 
 to your project.clj and download it from Clojars with
 


### PR DESCRIPTION
The instruction for leiningen still used version 2.0.1 instead of 2.0.2.
