### PR TITLE
Allow EOL to have same first character as delimiter

### DIFF
--- a/src/clojure_csv/core.clj
+++ b/src/clojure_csv/core.clj
@@ -166,12 +166,12 @@ and quotes. The main functions are parse-csv and write-csv."}
             look-ahead (reader-peek csv-reader)]
        (cond (== -1 look-ahead)
              (persistent! (conj! fields last-field))
-             (== look-ahead (int delimiter))
-             (do (.skip csv-reader 1)
-                 (recur (conj! fields last-field) "" (reader-peek csv-reader)))
              (eol-at-reader-pos? csv-reader end-of-line)
              (do (skip-past-eol csv-reader end-of-line)
                  (persistent! (conj! fields last-field)))
+             (== look-ahead (int delimiter))
+             (do (.skip csv-reader 1)
+                 (recur (conj! fields last-field) "" (reader-peek csv-reader)))
              (== look-ahead (int quote-char))
              (recur fields
                     (read-quoted-field csv-reader delimiter quote-char strict)

--- a/test/clojure_csv/test/core.clj
+++ b/test/clojure_csv/test/core.clj
@@ -128,4 +128,6 @@
   (is (= [["a" "bHELLO"] ["c" "d"]] (parse-csv "a,\"bHELLO\"HELLOc,d"
                                             :end-of-line "HELLO")))
   (is (= [["a" "b\r"] ["c" "d"]] (parse-csv "a,|b\r|\rc,d"
-                                            :end-of-line "\r" :quote-char \|))))
+                                            :end-of-line "\r" :quote-char \|)))
+  ;; Edge-case: If the EOL begins with the same character as the delimiter
+  (is (= [["a" "b"] ["c" "d"]] (parse-csv "a^b^+^c^d" :delimiter \^ :end-of-line "^+^"))))


### PR DESCRIPTION
The changes here allow you to have an end-of-line string that _begins_ with the same character that is used as the delimiter. An example that I've come across in the wild is a delimiter of `^` with an end-of-line sequence of `^+^`.

Not defending it, just need to support it. I'd welcome your thoughts.