### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Recent Updates
   parse-csv is now a string or Reader, and a new API based on keyword
   args instead of rebinding vars.
 
-###Previously...
+### Previously...
 * Updated library to 1.3.2.
 * Added support for changing the character used to start and end quoted fields in
   reading and writing.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
