### PR TITLE
Escaped characters inside of quoted fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Recent Updates
   parse-csv is now a string or Reader, and a new API based on keyword
   args instead of rebinding vars.
 
-###Previously...
+### Previously...
+
 * Updated library to 1.3.2.
 * Added support for changing the character used to start and end quoted fields in
   reading and writing.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-csv "2.0.2"
+(defproject clojure-csv "2.0.3"
   :description "A simple library to read and write CSV files."
   :dependencies [[org.clojure/clojure "1.3.0"]]
   :plugins [[perforate "0.3.2"]]

--- a/src/clojure_csv/core.clj
+++ b/src/clojure_csv/core.clj
@@ -121,6 +121,9 @@ and quotes. The main functions are parse-csv and write-csv."}
     (.reset reader)
     result))
 
+
+(def ^:private escape-character (int \\))
+
 (defn- read-quoted-field
   "Given a reader that is queued up to the beginning of a quoted field,
    reads the field and returns it as a string. The reader will be left at the
@@ -141,6 +144,12 @@ and quotes. The main functions are parse-csv and write-csv."}
             (do (.appendCodePoint field-str quote-char)
                 (.skip reader 2)
                 (recur (reader-peek reader)))
+            ;; If we see an escaping character, skip it and add the character
+            (= escape-character c)
+            (do
+              (.skip reader 1)
+              (.appendCodePoint field-str (.read reader))
+              (recur (reader-peek reader)))
             ;; Otherwise, if we see a single quote char, this field has ended.
             ;; Skip past the ending quote and return the field.
             (== c quote-char)

--- a/test/clojure_csv/test/core.clj
+++ b/test/clojure_csv/test/core.clj
@@ -20,6 +20,7 @@
 (deftest quoting
   (is (= [[""]] (parse-csv "\"")))
   (is (= [["\""]] (parse-csv "\"\"\"")))
+  (is (= [["nested", "\"quote\""]] (parse-csv "nested,\"\\\"quote\\\"\"" )))
   (is (= [["Before", "\"","After"]] (parse-csv "Before,\"\"\"\",After")))
   (is (= [["Before", "", "After"]] (parse-csv "Before,\"\",After")))
   (is (= [["", "start&end", ""]] (parse-csv "\"\",\"start&end\",\"\"")))


### PR DESCRIPTION
This PR fixes the issue of clojure-csv being unable to handle escaped characters inside of quoted fields.